### PR TITLE
Update regression card, increased timeout

### DIFF
--- a/bundle/index.js
+++ b/bundle/index.js
@@ -32,8 +32,7 @@ __export(constants_exports, {
   PULL_REQUEST_CHECKS_TIMEOUT: () => PULL_REQUEST_CHECKS_TIMEOUT,
   PULL_REQUEST_REFETCH_LIMIT: () => PULL_REQUEST_REFETCH_LIMIT,
   PULL_REQUEST_REFETCH_TIMEOUT: () => PULL_REQUEST_REFETCH_TIMEOUT,
-  REDMINE_API_URL: () => REDMINE_API_URL,
-  STATUSES: () => STATUSES
+  REDMINE_API_URL: () => REDMINE_API_URL
 });
 module.exports = __toCommonJS(constants_exports);
 const MERGE_DELAY = 2 * 60 * 1e3;
@@ -44,12 +43,6 @@ const PULL_REQUEST_CHECKS_LIMIT = 120;
 const CIRCLECI_API_URL = "https://circleci.com/api/v2";
 const CLICKUP_API_URL = "https://api.clickup.com/api/v2";
 const REDMINE_API_URL = "https://redmine.deriv.cloud";
-var STATUSES = /* @__PURE__ */ ((STATUSES2) => {
-  STATUSES2["PENDING_QA"] = "Pending - QA";
-  STATUSES2["READY_RELEASE"] = "Ready - Release";
-  STATUSES2["MERGED_RELEASE"] = "Merged - Release";
-  return STATUSES2;
-})(STATUSES || {});
 // Annotate the CommonJS export names for ESM import in node:
 0 && (0);
 //# sourceMappingURL=constants.js.map

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -1589,7 +1589,7 @@ class ReleaseWorkflow {
       await import_slack.default.updateChannelTopic(
         "task_release_planning_fe",
         "Deriv.app",
-        `- Deriv.app - ${import_config.TAG} - In Progress`
+        `- ${import_config.PLATFORM} - ${import_config.TAG} - In Progress`
       );
       import_logger.default.log("Release workflow has completed successfully!");
       this.logSummary(merged_issues, failed_issues, failed_notifications);

--- a/bundle/index.js
+++ b/bundle/index.js
@@ -596,14 +596,16 @@ class Clickup {
     if (!has_regression_testing_card) {
       import_logger.default.log(`Creating regression testing card with title ${title}...`, "loading");
       const task = await this.http.post(`list/${import_config.LIST_ID}/taskTemplate/${import_config.REGRESSION_TESTING_TEMPLATE_ID}`, {
-        name: title,
+        name: title
+      });
+      await this.updateIssue(task.id, {
         status: "Pending - QA"
       });
       regression_testing_card = {
         id: task.id,
         title: task.name,
         description: task.description,
-        status: task.status?.status
+        status: "Pending - QA"
       };
     } else {
       import_logger.default.log(`Regression testing card has already been created.`, "success");

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -1,8 +1,16 @@
 export const MERGE_DELAY = 2 * 60 * 1000;
 export const PULL_REQUEST_CHECKS_TIMEOUT = 1 * 60 * 1000; // 1 minute
 export const PULL_REQUEST_REFETCH_TIMEOUT = 5 * 1000; // 5 seconds
-export const PULL_REQUEST_REFETCH_LIMIT = 30; // the max amount of refetches to check for a pull request's status checks
+export const PULL_REQUEST_REFETCH_LIMIT = 10; // the max amount of refetches to check for a pull request's status checks
+export const PULL_REQUEST_CHECKS_LIMIT = 120;
 
 export const CIRCLECI_API_URL = "https://circleci.com/api/v2";
 export const CLICKUP_API_URL = "https://api.clickup.com/api/v2";
 export const REDMINE_API_URL = "https://redmine.deriv.cloud";
+
+
+export enum STATUSES {
+    PENDING_QA = 'Pending - QA',
+    READY_RELEASE = 'Ready - Release',
+    MERGED_RELEASE = 'Merged - Release'
+}

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -7,10 +7,3 @@ export const PULL_REQUEST_CHECKS_LIMIT = 120;
 export const CIRCLECI_API_URL = "https://circleci.com/api/v2";
 export const CLICKUP_API_URL = "https://api.clickup.com/api/v2";
 export const REDMINE_API_URL = "https://redmine.deriv.cloud";
-
-
-export enum STATUSES {
-    PENDING_QA = 'Pending - QA',
-    READY_RELEASE = 'Ready - Release',
-    MERGED_RELEASE = 'Merged - Release'
-}

--- a/src/utils/clickup.ts
+++ b/src/utils/clickup.ts
@@ -236,13 +236,15 @@ export class Clickup implements ReleaseStrategy {
             logger.log(`Creating regression testing card with title ${title}...`, 'loading');
             const task = await this.http.post<Task>(`list/${LIST_ID}/taskTemplate/${REGRESSION_TESTING_TEMPLATE_ID}`, {
                 name: title,
-                status: 'Pending - QA'
             });
+            await this.updateIssue(task.id, {
+                status: 'Pending - QA'
+            })
             regression_testing_card = {
                 id: task.id,
                 title: task.name,
                 description: task.description,
-                status: task.status?.status,
+                status: 'Pending - QA',
             };
         } else {
             logger.log(`Regression testing card has already been created.`, 'success');

--- a/src/utils/clickup.ts
+++ b/src/utils/clickup.ts
@@ -194,6 +194,9 @@ export class Clickup implements ReleaseStrategy {
                     add: [version.id],
                 },
             });
+        } else {
+            logger.log('Could not find Release Tag/Release Tags field, linking issue as a relationship instead.', 'error')
+            await this.addTaskRelationship(task.id, version.id);
         }
     }
 

--- a/src/utils/clickup.ts
+++ b/src/utils/clickup.ts
@@ -223,7 +223,7 @@ export class Clickup implements ReleaseStrategy {
     }
 
     async createRegressionTestingIssue(version: Issue): Promise<Issue> {
-        const title = `Deriv.app Regression Testing - ${TAG}`;
+        const title = `${PLATFORM} Regression Tag - ${TAG}`;
         const tasks = await this.fetchIssues(LIST_ID);
         const has_regression_testing_card = tasks.some(task => task.title === title);
         let regression_testing_card: Issue;
@@ -233,6 +233,7 @@ export class Clickup implements ReleaseStrategy {
             logger.log(`Creating regression testing card with title ${title}...`, 'loading');
             const task = await this.http.post<Task>(`list/${LIST_ID}/taskTemplate/${REGRESSION_TESTING_TEMPLATE_ID}`, {
                 name: title,
+                status: 'Pending - QA'
             });
             regression_testing_card = {
                 id: task.id,

--- a/src/utils/workflow.ts
+++ b/src/utils/workflow.ts
@@ -4,7 +4,7 @@ import slack from './slack';
 import { loadUserHasFailedIssuesMsg } from './slack/messages';
 import { IssueError } from 'models/error';
 import logger from './logger';
-import { LIST_ID, TAG } from './config';
+import { LIST_ID, PLATFORM, TAG } from './config';
 import { SlackUser } from 'models/slack';
 
 export class ReleaseWorkflow {
@@ -126,7 +126,7 @@ export class ReleaseWorkflow {
             await slack.updateChannelTopic(
                 'task_release_planning_fe',
                 'Deriv.app',
-                `- Deriv.app - ${TAG} - In Progress`
+                `- ${PLATFORM} - ${TAG} - In Progress`
             );
 
             logger.log('Release workflow has completed successfully!');


### PR DESCRIPTION
- Updated regression testing card title
- Increased timeout and added extra counters
- Set default to link task by relationship if `Release Tag` or `Release Tags` field does not exist